### PR TITLE
Abdicate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,4 @@ os:
   - linux
 sudo: required
 
-before_install:
- - if [ $TRAVIS_OS_NAME = osx ]; then brew install coreutils; fi
-
 script: sudo -E ./tests/run-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-os:
-  - osx
-  - linux
 sudo: required
-
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      dist: trusty
+    - os: linux
+      dist: precise
 script: sudo -E ./tests/run-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ os: linux
 sudo: required
 
 before_install:
- - id
- - sudo usermod -a -G sudo $USER
- - id
- - echo "%sudo  ALL=(ALL) NOPASSWD: ALL" | EDITOR="tee" sudo visudo
+ - |
+   sudo adduser myadmin --group sudo
+   echo '%sudo ALL=(ALL:ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 script:
- - bash tests/test_delayed_admin.sh
+ - sudo -u myadmin bash ./tests/test_delayed_admin.sh

--- a/Readme.md
+++ b/Readme.md
@@ -3,12 +3,12 @@
 
 A tool for administrators to (temporarily) drop admin privileges - to use tools like [Parental Controls](https://support.apple.com/kb/PH18571), [Self Control](http://selfcontrolapp.com), [etc.](https://github.com/miheerdew/delayed-admin/wiki/Tools), on themselves!
 
-Currently, it's tested on MacOS, but should work on Unix like systems. The aim is to create a tool like [abmindicate](http://www.pluckeye.net/abmindicate.html) for MacOS/Unix.
+The code has been [tested](https://travis-ci.org/miheerdew/delayed-admin) on MacOS and Ubuntu, but it should work for other unix like systems too. 
 
-Feel free to open a pull request if you have any suggestions/feedback.
+Feel free to open a pull request if you have any suggestions or feedback.
 
 ## Warning
-**Follow these instructions only if you know what you are doing. There might be a possibility of locking yourself out of admin privileges. To prevent this, make another administrator account.**
+**There might be a possibility of locking yourself out of admin privileges. To prevent this, keep another administrator account which you can access if things go wrong.** 
 
 ## Tutorials
 [Tutorial for linux](https://www.ostechnix.com/delayed-admin-temporarily-drop-admin-privileges-administrators/) by SK.
@@ -18,7 +18,7 @@ Feel free to open a pull request if you have any suggestions/feedback.
 ### First an analogy
 Say you have a box containing an endless supply of candies, and that lately you have been eating lot more candy than you should be. After all, whenever you have an impulse to eat candy, it is so easy to just open the box and grab one. It's so hard to fight the craving!
 
- Now, imagine instead that the box had a mechanism to ensures that it only opens 20 min after you tell it to. Then it would be so much easier to resist the temptation of eating the candy (becuse even though the craving is there, there is nothing you can do about it, at least until the next 20 min).
+ Now, imagine instead that the box had a mechanism to ensure that it only opens 20 min after you tell it to. Then it would be so much easier to resist the temptation of eating the candy (becuse even though the craving is there, there is nothing you can do about it, at least until the next 20 min).
 
 This is the principle Delayed Admin is based upon. It gives you a delayed access to admin privilieges (the candy-box).
 
@@ -29,60 +29,84 @@ On installation, a new group called `delayed-admin` is created with an entry in 
 
 ## Why would anyone use this?
 
- Self-control. Suppose Anand runs MacOS/Linux on his laptop. He wants to enforce a no-screen time and restrict his visits to certain websites. Sure, he can install [a parental control app](http://www.noobslab.com/2017/01/timekpr-parental-control-application.html), or [change some settings](https://serverfault.com/a/139794), or use [url-blacklists](https://github.com/StevenBlack/hosts). But being an administrator for his laptop, he can also uninstall that program, remove those settings anytime.
+ Self-control. Suppose Anand runs MacOS/Linux on his laptop. He wants to enforce a no-screen time and restrict his visits to certain websites. Sure, he can install [a parental control app](http://www.noobslab.com/2017/01/timekpr-parental-control-application.html), or [change some settings](https://serverfault.com/a/139794), or use [url-blacklists](https://github.com/StevenBlack/hosts). But being an administrator for his laptop, he can also uninstall that program, or remove those settings anytime.
 
-This is where delayed admin helps. Anand only retains a delayed adminstrator access, so that he can still do the routine system update (or any other administrator stuff), but only after waiting for a slight delay (default is 30s but he can change it to 20 min). Basically, this prevents him from taking actions at whim, allowing only deliberate ones.
+This is where Delayed Admin would help. Anand only retains a delayed adminstrator access, so that he can still do the routine system update (or any other administrator stuff that he wants), but only after waiting for some time (by default it is 30s but he can change it to 20 min). Basically, this prevents him from taking actions at whim, allowing only deliberate ones.
 
-In this example he would set up those parental controls, and then use delayed admin to deter him from disabling them.
+In this example he would set up those parental controls, and then use `delayed` to deter him from disabling them.
 
-## Installation and setup
+## How to use it?
 
-### MacOS
+### Install
+To install, change to the delayed-admin directory and run:
 
 ```
-#Install delayed-admin
 sudo ./setup.sh install
-
-#Add the current user to the delayed-admin group
-sudo dseditgroup -o edit -a "$USER" -t user delayed-admin
-
-#Remove the current user from the admin group
-sudo dseditgroup -o edit -d "$USER" -t user admin
 ```
 
-### Linux
+This will go through a couple of actions. Ensure that the installation was successful before moving further. 
+
+
+
+### Usage
+
+There are two ways to use Delayed-Admin, as a timed lock and using the unlock delay. 
+
+1. **Timed Lock:** This will pause adminstrator access till the specified period of time. 
+
+	For instance, if Anand wants to forgo his adminstrator access for the next 2 hours, he can run:
+	
+	```
+	sudo ./abdicate.sh "now+2hr"
+	```
+	
+	He will now be an ordinary user for the next 2 hours (he might have to log off for changes to completely take effect), after which he will regain administrator access. The time argument is the time at which the adminstrator access should be reagined (see `man at` for the time format). 
+	
+2. **Unlock Delay:** This is a slighlty more complicated concept, but it is the heart of Delayed-Admin. The [analogy](#first-an-analogy) describes this, but you  can think of it as back-door to admin privileges which requires a delay to open.
+
+   To see the usage, let us take a scenario. Suppose Anand has already set up a program that logs him out between 10 PM-6 AM. Now, he doesn't wants to use his adminstrator access impulsively so he [installs](#install) Delayed-Admin. After this he should:
+   
+    - Add himself to the `delayed-admin` group
+      
+      ```
+      # On Ubuntu: 
+      sudo usermod -a -G delayed-admin "$USER"
+      # On MacOS:
+      sudo dseditgroup -o edit -a "$USER" -t user delayed-admin
+      ```
+    - Remove himself from the `admin` (or `sudo`) group
+
+      ```
+      # On Ubuntu: 
+      sudo gpasswd -d "$USER" sudo
+      # On MacOS:
+      sudo dseditgroup -o edit -d "$USER" -t user admin
+      ```
+    - That is it.., until he wants to use his adminstrator access again:
+      
+      ```
+      # # Does not work: 
+      # sudo whoami
+      # # Sorry, user Anand is not allowed to execute as root
+      
+      sudo delayed whoami
+      # Wait for 30s before returning 
+      # root
+      
+      sudo delayed
+      # Wait for 30s before returning a root shell
+      ```    
+      He can, of course, change the delay to a larger value by editing the file `/etc/delayed-admin.conf` 
+      
+      **Exercise:** After following the above instructions, change the value of delay from 30s to 1200s (i.e 20min). 
+
+### Uninstall
+
+First, add youself back the `admin` (or `sudo`) group if you had removed yourself. Then to undo the changes made during the install step, run:
 
 ```
-#Install delayed-admin
 sudo ./setup.sh install
-
-#Add the current user to the delayed-admin group
-usermod -a -G delayed-admin "$USER"
-
-#Remove the current user from the sudo group
-sudo gpasswd -d "$USER" sudo
 ```
-
-## Uninstall
-Before you uninstall, first ensure that you have root access. Then run:
-
-```
-sudo ./setup.sh uninstall
-```
-
-## Usage
-
-If you followed the instruction in [Installation and Setup](#installation-and-setup), now your account must belong to the `delayed-admin` group, but not to the `admin` (or `sudo`) group. Hence you can't directly run `sudo` on any command, but you can run `sudo delayed`:
-
-```
-sudo delayed whoami
-# Outputs "root" after 30 sec.
-
-sudo delayed
-# Get a root shell after 30 sec.
-```
-
-The delay can be changed by changing the number of seconds in `/etc/delayed-admin.conf`. After you are comfortable, it is recommended to change it to 1200 (i.e. 20 min).
 
 ## License
 

--- a/abdicate.sh
+++ b/abdicate.sh
@@ -11,7 +11,7 @@ Usage: sudo $0 TIME
 
 Explaination
 
-  TIME: Steal (i.e pause) admin access till TIME.
+  TIME: Pause admin access till TIME.
         TIME should be in a format recongnizable by the at command.
 
 This script will schedule an at command to restore admin access at time TIME.

--- a/abdicate.sh
+++ b/abdicate.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+. lib/utils.sh
+
+readonly TIME="$1"
+readonly USER="$SUDO_USER"
+
+function usage {
+  cat <<_EOF
+Usage: sudo $0 TIME
+
+Explaination
+
+  TIME: The time in seconds to steal (i.e pause) admin access.
+
+_EOF
+}
+
+
+if [ "$EUID" -ne 0 ] || [ -z "$USER" ]; then
+    echo "Please run using sudo"
+    usage
+    exit -1
+fi
+
+case $TIME in
+    ''|*[!0-9]*) echo "TIME is not an integer"
+	         usage
+		 exit -1
+esac
+
+add_user_to_group "$USER" delayed-admin
+log "Added $USER to the group delayed-admin"
+
+remove_user_from_group "$USER" "$ADMIN_GROUP"
+log "Removed $USER from group $ADMIN_GROUP"
+
+echo "Sleeping for $TIME seconds starting from $(date '+%D %T')"
+sleep "$TIME"
+
+add_user_to_group "$USER" "$ADMIN_GROUP"
+log "Added $USER to the $ADMIN_GROUP"

--- a/abdicate.sh
+++ b/abdicate.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-set -e
-
 . lib/utils.sh
 
-readonly TIME="$1"
+readonly TIME="$@"
 readonly USER="$SUDO_USER"
 
 function usage {
@@ -13,32 +11,39 @@ Usage: sudo $0 TIME
 
 Explaination
 
-  TIME: The time in seconds to steal (i.e pause) admin access.
+  TIME: Steal (i.e pause) admin access till TIME.
+        TIME should be in a format recongnizable by the at command.
 
+This script will schedule an at command to restore admin access at time TIME.
+After this it will add user to the delayed-admin group and remove
+user from the $ADMIN_GROUP group.
 _EOF
 }
 
 
 if [ "$EUID" -ne 0 ] || [ -z "$USER" ]; then
-    echo "Please run using sudo"
+    echo "Please run using sudo."
     usage
     exit -1
 fi
 
-case $TIME in
-    ''|*[!0-9]*) echo "TIME is not an integer"
-	         usage
-		 exit -1
-esac
+if check_atd_is_running; then
+   log "atd is already running."
+else
+   start_atd
+   log "Starting atd."
+fi
+
+at $TIME <<_EOF
+`declare -f add_user_to_group`
+add_user_to_group '$USER' '$ADMIN_GROUP'
+_EOF
+log "Scheduled: Add $USER to $ADMIN_GROUP group at $TIME"
 
 add_user_to_group "$USER" delayed-admin
-log "Added $USER to the group delayed-admin"
+log "Added $USER to the delayed-admin group"
 
 remove_user_from_group "$USER" "$ADMIN_GROUP"
-log "Removed $USER from group $ADMIN_GROUP"
+log "Removed $USER from $ADMIN_GROUP group"
 
-echo "Sleeping for $TIME seconds starting from $(date '+%D %T')"
-sleep "$TIME"
-
-add_user_to_group "$USER" "$ADMIN_GROUP"
-log "Added $USER to the $ADMIN_GROUP"
+echo "You may need to log out for changes to take effect."

--- a/delayed.sh
+++ b/delayed.sh
@@ -4,7 +4,7 @@ set -e
 CONFIG_FILE='/etc/delayed-admin.conf'
 
 # use integer variable to ensure that delay is always an integer regardless of the contents of the CONFIG_FILE.
-declare -i delay="$(cat '$CONFIG_FILE')"
+declare -i delay=$(cat "$CONFIG_FILE")
 
 CMD=${@:-/bin/bash}
 

--- a/delayed.sh
+++ b/delayed.sh
@@ -9,7 +9,9 @@ declare -i delay=$(cat "$CONFIG_FILE")
 CMD=${@:-/bin/bash}
 
 echo "Sleeping for $delay seconds starting from $(date '+%D %T')"
-sleep $delay
+if [[ $delay -gt 0 ]]; then
+    sleep "$delay"
+fi
 echo "Running command '$CMD'"
 
 $CMD

--- a/lib/linux.sh
+++ b/lib/linux.sh
@@ -4,3 +4,7 @@ function gadd { groupadd "$1"; }
 function add_user_to_group { usermod -a -G "$2" "$1"; }
 function remove_user_from_group { gpasswd -d "$1" "$2"; }
 readonly ADMIN_GROUP="sudo"
+
+#TODO Implement these
+function check_atd_is_running { true; }
+function start_atd { true; }

--- a/lib/linux.sh
+++ b/lib/linux.sh
@@ -1,3 +1,6 @@
 function gexists { gentent group "$1" &> /dev/null; }
 function gdel { groupdel "$1"; }
 function gadd { groupadd "$1"; }
+function add_user_to_group { usermod -a -G "$2" "$1"; }
+function remove_user_from_group { gpasswd -d "$1" "$2"; }
+readonly ADMIN_GROUP="sudo"

--- a/lib/macos.sh
+++ b/lib/macos.sh
@@ -4,3 +4,6 @@ function gadd { dseditgroup -o create "$1"; }
 function add_user_to_group { dseditgroup -o edit -a "$1" -t user "$2"; }
 function remove_user_from_group { dseditgroup -o edit -d "$1" -t user "$2"; }
 readonly ADMIN_GROUP="admin"
+
+function check_atd_is_running { launchctl list | grep -q com.apple.atrun; }
+function start_atd { launchctl load -w /System/Library/LaunchDaemons/com.apple.atrun.plist; }

--- a/lib/macos.sh
+++ b/lib/macos.sh
@@ -1,3 +1,6 @@
 function gexists { dseditgroup -o read "$1" &>/dev/null; }
 function gdel { dseditgroup -o delete "$1"; }
 function gadd { dseditgroup -o create "$1"; }
+function add_user_to_group { dseditgroup -o edit -a "$1" -t user "$2"; }
+function remove_user_from_group { dseditgroup -o edit -d "$1" -t user "$2"; }
+readonly ADMIN_GROUP="admin"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,17 @@
+function log {
+   local msg="$1"
+   if [ $? -gt 0 ]; then
+     echo -e "[\xE2\x9D\x8C] $msg" 1>&2
+   else
+     echo -e "[\xE2\x9C\x94] $msg"
+   fi
+}
+
+case $OSTYPE in
+    darwin*) . ./lib/macos.sh
+             ;;
+    linux*) . ./lib/linux.sh
+            ;;
+    *) echo "Unknown OS."
+       exit 1;
+esac

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,7 +1,9 @@
 function log {
+   local err="${2-$?}"
    local msg="$1"
-   if [ $? -gt 0 ]; then
+   if [ $err -gt 0 ]; then
      echo -e "[\xE2\x9D\x8C] $msg" 1>&2
+     exit $err
    else
      echo -e "[\xE2\x9C\x94] $msg"
    fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,28 +2,13 @@
 
 set -e
 
-case $OSTYPE in
-    darwin*) . ./lib/macos.sh
-             ;;
-    linux*) . ./lib/linux.sh
-            ;;
-    *) echo "Unknown OS."
-       exit 1;
-esac
+. lib/utils.sh
 
 readonly GROUP_NAME="delayed-admin"
 readonly SUDOERS_FILE="/etc/sudoers.d/delayed-admin"
 readonly DELAYED="/usr/local/bin/delayed" # Must be the same as specified in sudoers file
 readonly CONFIG_FILE="/etc/delayed-admin.conf" # Must be the same as specified in delayed.sh
 
-function log {
-   local msg="$1"
-   if [ $? -gt 0 ]; then
-     echo -e "[\xE2\x9D\x8C] $msg" 1>&2
-   else
-     echo -e "[\xE2\x9C\x94] $msg"
-   fi
-}
 
 function create_group {
     local grp="$1"

--- a/tests/run-travis
+++ b/tests/run-travis
@@ -29,3 +29,4 @@ rm -f /etc/sudoers.d/*
 ls /etc/sudoers.d
 
 su $NEW_USER -c 'bash ./tests/test_delayed_admin.sh'
+su $NEW_USER -c 'bash ./tests/test_abdicate.sh'

--- a/tests/test_abdicate.sh
+++ b/tests/test_abdicate.sh
@@ -1,9 +1,11 @@
 testAbdicate(){
   sudo ./setup.sh install || fail "Delayed-admin installation failed"
   sudo ./abdicate.sh "now+1min" || fail "Abdicate failed"
-  sudo true && fail "Sudo access is not revoked"
+  check_access_is_revoked || fail "Sudo access is not revoked"
   sleep 100
-  sudo true || fail "Sudo access is not restored"
+  check_access_is_restored || fail "Sudo access is not restored"
+  sudo ./setup.sh uninstall || fail "Uninstallation failed"
 }
 
+. tests/tools.sh
 . tests/shunit2

--- a/tests/test_abdicate.sh
+++ b/tests/test_abdicate.sh
@@ -1,12 +1,16 @@
 . tests/tools.sh
 
 testAbdicate(){
-  sudo ./setup.sh install || fail "Delayed-admin installation failed"
+  sudo ./setup.sh install || fail "Installation failed"
   sudo ./abdicate.sh "now+1min" || fail "Abdicate failed"
   check_access_is_revoked || fail "Sudo access is not revoked"
   sleep 100
   check_access_is_restored || fail "Sudo access is not restored"
-  sudo ./setup.sh uninstall || fail "Uninstallation failed"
+  sudo ./setup.sh uninstall || fail "Uninstall failed"
 }
 
+testAbdicateWithoutDelayedAdmin() {
+  sudo ./abdicate.sh "now+1min" && fail "Abdicate did not err without Delayed Admin"
+  check_access_is_restored || fail "Sudo access is not restored"
+}
 . tests/shunit2

--- a/tests/test_abdicate.sh
+++ b/tests/test_abdicate.sh
@@ -1,0 +1,9 @@
+testAbdicate(){
+  sudo ./setup.sh install || fail "Delayed-admin installation failed"
+  sudo ./abdicate.sh "now+1min" || fail "Abdicate failed"
+  sudo true && fail "Sudo access is not revoked"
+  sleep 100
+  sudo true || fail "Sudo access is not restored"
+}
+
+. tests/shunit2

--- a/tests/test_abdicate.sh
+++ b/tests/test_abdicate.sh
@@ -1,3 +1,5 @@
+. tests/tools.sh
+
 testAbdicate(){
   sudo ./setup.sh install || fail "Delayed-admin installation failed"
   sudo ./abdicate.sh "now+1min" || fail "Abdicate failed"
@@ -7,5 +9,4 @@ testAbdicate(){
   sudo ./setup.sh uninstall || fail "Uninstallation failed"
 }
 
-. tests/tools.sh
 . tests/shunit2

--- a/tests/test_delayed_admin.sh
+++ b/tests/test_delayed_admin.sh
@@ -14,26 +14,5 @@ testDelayed() {
   sudo ./setup.sh uninstall || fail "Uninstall not successful"
 }
 
-function with_sudo {
-  local func_name=$1
-  shift
-  sudo bash <<_EOF
-`declare -f $func_name`
-$func_name $@
-_EOF
-}
-
-function with_delayed {
-  local func_name=$1
-  shift
-  sudo /usr/local/bin/delayed <<_EOF
-`declare -f $func_name`
-$func_name $@
-_EOF
-}
-
-function check_access_is_revoked {
- #Check if we can execute the true command (under a new login if required)
- ! ( sudo -n true && sudo -n su $USER -c "sudo -n /bin/true" )
-}
+. tests/tools.sh
 . tests/shunit2

--- a/tests/tools.sh
+++ b/tests/tools.sh
@@ -1,0 +1,26 @@
+function with_sudo {
+  local func_name=$1
+  shift
+  sudo bash <<_EOF
+`declare -f $func_name`
+$func_name $@
+_EOF
+}
+
+function with_delayed {
+  local func_name=$1
+  shift
+  sudo /usr/local/bin/delayed <<_EOF
+`declare -f $func_name`
+$func_name $@
+_EOF
+}
+
+function check_access_is_revoked {
+ #Check if we can execute the true command (under a new login if required)
+ ! ( sudo -n true && sudo -n su $USER -c "sudo -n true" )
+}
+
+function check_access_is_restored {
+  sudo su $USER -c "sudo true"
+}


### PR DESCRIPTION
Adds `abdicate.sh` that allows administrators to temporarily drop sudo privileges till a specified time.
This script removes user from the admin/sudo group and schedules adding the user back at a specified time. The delayed-admin group is use to maintain a backdoor if something goes wrong. This is proposed as a solution to #4 . 

Comprehensive tests have been added for delayed-admin. 