### PR TITLE
Add Arch/Manjaro to admin_group

### DIFF
--- a/lib/linux.sh
+++ b/lib/linux.sh
@@ -12,7 +12,7 @@ function admin_group() {
     ubuntu|debian)
       echo "sudo"
       ;;
-    centos|fedora|rhel|arch)
+    centos|fedora|rhel|arch|manjaro)
       echo "wheel"
       ;;
   esac

--- a/lib/linux.sh
+++ b/lib/linux.sh
@@ -12,7 +12,7 @@ function admin_group() {
     ubuntu|debian)
       echo "sudo"
       ;;
-    centos|fedora|rhel)
+    centos|fedora|rhel|arch)
       echo "wheel"
       ;;
   esac


### PR DESCRIPTION
According to [packages/filesystem](https://git.archlinux.org/svntogit/packages.git/tree/trunk/os-release?h=packages/filesystem) (found via [this snippet](https://gist.github.com/natefoo/814c5bf936922dad97ff#file-arch-md)) and to [Sudo documentation](https://wiki.archlinux.org/index.php/Sudo#Example_entries), the `distro_id` for Arch should be `arch` and the administrators group should be `wheel`. Same for [Manjaro](https://gitlab.manjaro.org/packages/core/filesystem/-/blob/master/os-release).
I don't have Arch, so I can't test this, but hopefully it should work.
Fixes #10 