### PR TITLE
Add support for EndeavourOS in admin group detection

### DIFF
--- a/lib/linux.sh
+++ b/lib/linux.sh
@@ -12,7 +12,7 @@ function admin_group() {
     ubuntu|debian)
       echo "sudo"
       ;;
-    centos|fedora|rhel|arch|manjaro)
+    centos|fedora|rhel|arch|manjaro|endeavouros)
       echo "wheel"
       ;;
   esac


### PR DESCRIPTION
This PR adds "endeavouros" to the list of distributions using the "wheel" group for admin privileges in `lib/linux.sh`.

Tested on EndeavourOS where `ID=endeavouros` in `/etc/os-release`.
